### PR TITLE
feat: se agregaron los endpoints de refreshToken, logout y pruebas unitarias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
@@ -2205,6 +2206,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt": "^6.0.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/src/config/app.js
+++ b/src/config/app.js
@@ -9,6 +9,7 @@ const usuarios = require('../modules/usuarios');
 const estadisticas = require('../modules/estadisticas');
 const requestLogger = require("../core/middlewares/requestLogger.middleware");
 const logger = require("../core/utils/logger");
+const cookieParser = require("cookie-parser");
 
 // Configuración de CORS
 const corsOptions = {
@@ -29,6 +30,7 @@ const corsOptions = {
 app.use(cors(corsOptions));
 app.use(express.json());
 app.use(requestLogger); 
+app.use(cookieParser()); 
 
 
 // Health check endpoint

--- a/src/core/utils/hash.js
+++ b/src/core/utils/hash.js
@@ -14,6 +14,8 @@ async function comparePassword(password, hashed) {
   if (!password || typeof password !== 'string' || !hashed || typeof hashed !== 'string') {
     throw new Error('La contraseña y el hash deben ser cadenas de texto válidas');
   }
+  const match = await bcrypt.compare(password, hashed);
+  return match;
 }
 
 module.exports = { hashPassword, comparePassword };

--- a/src/modules/auth/auth.controller.js
+++ b/src/modules/auth/auth.controller.js
@@ -4,8 +4,51 @@ const AuthService = require("./auth.service");
 exports.login = async (req, res, next) => {
   try {
     const { email, password } = req.body;
-    const result = await AuthService.login(email, password);
-    res.json(result);
+    const ip = req.ip;
+    const userAgent = req.headers["user-agent"];
+    const {json, cookies, refreshToken} = await AuthService.login(email, password, ip, userAgent);
+    res.cookie("refreshToken", refreshToken, cookies);
+    res.json({
+      success: true,
+      data: json,
+      mensaje: "Inicio de sesión exitoso"
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+
+exports.refreshToken = async (req, res, next) => {
+  try{
+    const token = req.cookies.refreshToken; 
+    const ip = req.ip;
+    const userAgent = req.headers["user-agent"];
+    const {json, cookies, refreshToken} = await AuthService.refreshToken(token, ip, userAgent);
+    res.cookie("refreshToken", refreshToken, cookies);
+    res.json({
+      success: true,
+      data: json,
+      mensaje: "Token refrescado"
+    });
+  }
+  catch(err){
+    next(err);
+  }
+};
+
+
+exports.logout = async (req, res, next) => {
+  try {
+    const usuarioId = req.user.sub;
+    const result = await AuthService.logout(usuarioId);
+    res.clearCookie("refreshToken", {path: "/api/auth/refreshToken"});
+    res.json({
+      success: true,
+      data: result,
+      mensaje: "Cierre de sesión exitoso"
+    })
+    res.status(204).send();
   } catch (err) {
     next(err);
   }

--- a/src/modules/auth/auth.controller.js
+++ b/src/modules/auth/auth.controller.js
@@ -42,13 +42,12 @@ exports.logout = async (req, res, next) => {
   try {
     const usuarioId = req.user.sub;
     const result = await AuthService.logout(usuarioId);
-    res.clearCookie("refreshToken", {path: "/api/auth/refreshToken"});
+    res.clearCookie("refreshToken", {path: "/"});
     res.json({
       success: true,
       data: result,
       mensaje: "Cierre de sesión exitoso"
-    })
-    res.status(204).send();
+    });
   } catch (err) {
     next(err);
   }

--- a/src/modules/auth/auth.model.js
+++ b/src/modules/auth/auth.model.js
@@ -1,0 +1,35 @@
+const mongoose = require("mongoose");
+
+const RefreshTokenSchema = new mongoose.Schema({
+  usuarioId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Usuario",
+    required: true,
+    index: true,
+  },
+  tokenHash: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  infoDispositivo: {
+    ip: String,
+    userAgent: String,
+  },
+  fechaExpiracion: {
+    type: Date,
+    required: true,
+    index: { expires: 0 }   
+  },
+  reemplazadoPor: {
+    type: String,
+  },
+  fechaRevocacion: {
+    type: Date,
+  }
+},
+{
+  timestamps: true,
+});
+
+module.exports = mongoose.model("RefreshToken", RefreshTokenSchema);

--- a/src/modules/auth/auth.repository.js
+++ b/src/modules/auth/auth.repository.js
@@ -1,12 +1,90 @@
 // src/modules/auth/auth.repository.js
-// Encargado de acceso a datos. No debe conocer ni bcrypt ni JWT; solo gestiona consultas de usuarios.
-
-const Usuario = require("../usuarios/usuario.model");
+// Encargado de acceso a datos. No debe conocer ni bcrypt ni JWT;
+// solo gestiona consultas a Usuario y RefreshToken.
+const RefreshToken = require("./auth.model");
 
 const AuthRepository = {
-  findByEmail: async (email) => {
-    return await Usuario.findOne({ email: email.toLowerCase() });
+
+  // ========================
+  // REFRESH TOKENS
+  // ========================
+
+  createRefreshToken: async (data) => {
+    return await RefreshToken.create(data);
   },
+
+  /**
+   * Revoca el refresh token activo más reciente de un usuario
+   */
+  revocarUltimoRefreshToken: async (
+    usuarioId,
+    fechaRevocacion = new Date(),
+    reemplazadoPor = null
+  ) => {
+    return await RefreshToken.findOneAndUpdate(
+      {
+        usuarioId,
+        fechaRevocacion: { $exists: false }
+      },
+      {
+        $set: {
+          fechaRevocacion,
+          ...(reemplazadoPor && { reemplazadoPor })
+        }
+      },
+      {
+        sort: { createdAt: -1 },
+        new: true
+      }
+    );
+  },
+
+  /**
+   * Obtiene el refresh token ACTIVO del usuario:
+   * - no revocado
+   * - no expirado
+   */
+  findRefreshTokenActivo: async (usuarioId) => {
+    return await RefreshToken.findOne({
+      usuarioId,
+      fechaRevocacion: { $exists: false },
+      fechaExpiracion: { $gt: new Date() }
+    }).sort({ createdAt: -1 });
+  },
+
+  /**
+   * Elimina todos los refresh tokens antiguos,
+   * manteniendo solo los 2 más recientes
+   */
+  limpiarTokensAntiguos: async (usuarioId) => {
+    const tokensAntiguos = await RefreshToken.find({ usuarioId })
+      .sort({ createdAt: -1 })
+      .skip(2)
+      .select("_id");
+
+    if (!tokensAntiguos.length) return;
+
+    await RefreshToken.deleteMany({
+      _id: { $in: tokensAntiguos.map(t => t._id) }
+    });
+  },
+
+  /**
+   * Revoca TODOS los refresh tokens del usuario (logout global)
+   */
+  revocarTodosLosTokens: async (usuarioId, fechaRevocacion = new Date()) => {
+    return await RefreshToken.updateMany(
+      {
+        usuarioId,
+        fechaRevocacion: { $exists: false }
+      },
+      {
+        $set: { fechaRevocacion }
+      }
+    );
+  },
+
+  findbyHashToken: async (tokenHash) => {return await RefreshToken.findOne({ tokenHash });}
 };
 
 module.exports = AuthRepository;

--- a/src/modules/auth/auth.routes.js
+++ b/src/modules/auth/auth.routes.js
@@ -4,7 +4,13 @@
 const express = require("express");
 const router = express.Router();
 const controller = require("./auth.controller");
+const {verifyToken} = require("../../core/middlewares/auth.middleware");
+
 
 router.post("/login", controller.login);
+
+router.post("/refreshToken", controller.refreshToken);
+
+router.post("/logout", verifyToken, controller.logout);
 
 module.exports = router;

--- a/src/modules/auth/auth.service.js
+++ b/src/modules/auth/auth.service.js
@@ -2,33 +2,30 @@
 // Contiene la lógica de negocio del login: validaciones, comparación de contraseñas y generación del token.
 // No maneja req ni res — solo datos y errores.
 
-const bcrypt = require("bcrypt");
-const jwt = require("jsonwebtoken");
 const AuthRepository = require("./auth.repository");
+const UsuarioRepository = require("../usuarios/usuario.repository");
+const AuthUtils = require("./auth.utils");
+const {comparePassword} = require("../../core/utils/hash");
 
 const JWT_SECRET = process.env.JWT_SECRET;
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
-
-if (!JWT_SECRET) {
-  console.warn("Warning: JWT_SECRET is not set. Set in environment for production.");
-}
 
 const AuthService = {
-  async login(email, password) {
+  //Inicio de sesión
+  async login(email, password, ip, userAgent) {
     if (!email || !password) {
       const error = new Error("Email y password son requeridos");
       error.status = 400;
       throw error;
     }
 
-    const usuario = await AuthRepository.findByEmail(email);
+    const usuario = await UsuarioRepository.findByEmailExact(email);
     if (!usuario) {
       const error = new Error("Credenciales inválidas");
       error.status = 401;
       throw error;
     }
 
-    const match = await bcrypt.compare(password, usuario.password);
+    const match = await comparePassword(password, usuario.password);
     if (!match) {
       const error = new Error("Credenciales inválidas");
       error.status = 401;
@@ -41,25 +38,70 @@ const AuthService = {
       throw error;
     }
 
-    const payload = {
-      sub: usuario._id.toString(),
-      email: usuario.email,
-      rol: usuario.rol,
-    };
+    return await AuthUtils.refreshToken(usuario, ip, userAgent);
 
-    const token = jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
+  },
 
-    return {
-      token,
+
+  // Refrescar token de sesión
+  async refreshToken(refreshToken, ip, userAgent){
+    if(!refreshToken){
+      const error = new Error("Refresh token no entregado");
+      error.status = 400;
+      throw error;
+    }
+
+    const givenToken = AuthUtils.hashToken(refreshToken)
+    const savedToken = await AuthRepository.findbyHashToken(givenToken)
+    if(!savedToken){
+      const error = new Error("Refresh token no válido");
+      error.status = 401;
+      throw error;
+    }
+    if(savedToken.fechaRevocacion){
+      const error = new Error("Refresh token no válido");
+      error.status = 401;
+      throw error;
+    }
+    if(new Date() > savedToken.fechaExpiracion){
+      const error = new Error("Refresh token no válido");
+      error.status = 401;
+      throw error;
+    }
+
+    const usuario = await UsuarioRepository.findById(savedToken.usuarioId);
+    if (!usuario) {
+      const error = new Error("Refresh token no válido");
+      error.status = 401;
+      throw error;
+    }
+    
+    return await AuthUtils.refreshToken(usuario, ip, userAgent);
+
+  },
+
+  // Cierre de sesión
+  async logout(usuarioId){
+    const usuario = await UsuarioRepository.findById(usuarioId);
+    if (!usuario) {
+      const error = new Error("Token no válido");
+      error.status = 401;
+      throw error;
+    }
+    // Revocamos los tokens
+    AuthRepository.revocarTodosLosTokens(usuarioId);
+    // El access token es eliminado desde el frontend
+    return{
       user: {
         id: usuario._id,
         nombre: usuario.nombre,
         email: usuario.email,
         rol: usuario.rol,
         activo: usuario.activo,
-      },
-    };
-  },
+      }
+    }
+  }
 };
+
 
 module.exports = AuthService;

--- a/src/modules/auth/auth.utils.js
+++ b/src/modules/auth/auth.utils.js
@@ -92,8 +92,8 @@ exports.refreshToken = async (usuario, ip, userAgent) => {
     const cookies = {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
-        sameSite: "strict",
-        path: "/api/auth/refreshToken",
+        sameSite: process.env.NODE_ENV === "production" ? "strict" : "lax",
+        path: "/",  // Cambiar de /api/auth/refreshToken a / para desarrollo
         maxAge: ms(REFRESH_JWT_EXPIRES_IN)
     }
 

--- a/src/modules/auth/auth.utils.js
+++ b/src/modules/auth/auth.utils.js
@@ -1,0 +1,105 @@
+const crypto = require('crypto');
+const AuthRepository = require('./auth.repository');
+const ACCESS_JWT_EXPIRES_IN = process.env.ACCESS_JWT_EXPIRES_IN || "15min";
+const REFRESH_JWT_EXPIRES_IN = process.env.REFRESH_JWT_EXPIRES_IN || "7d";
+const jwt = require("jsonwebtoken");
+const ms = require("ms");
+
+const JWT_SECRET = process.env.JWT_SECRET;
+
+if (!JWT_SECRET) {
+  console.warn("Warning: JWT_SECRET is not set. Set in environment for production.");
+}
+
+function generarFechaExpiracion(expiresIn) {
+  const match = expiresIn.match(/^(\d+)([smhd])$/);
+
+  if (!match) {
+    const error = new Error(`Formato inválido de expiración: ${expiresIn}`);
+    error.status = 500;
+    throw error;
+  }
+
+  const valor = parseInt(match[1], 10);
+  const unidad = match[2];
+
+  const multiplicadores = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000
+  };
+
+  return new Date(Date.now() + valor * multiplicadores[unidad]);
+}
+
+exports.generarRefreshToken = () => {
+  return crypto.randomBytes(64).toString("hex"); // 128 chars
+};
+
+exports.hashToken = (token) => {
+  return crypto
+    .createHash("sha256")
+    .update(token)
+    .digest("hex");
+};
+
+exports.refreshToken = async (usuario, ip, userAgent) => {
+    // Revocar token anterior
+    await AuthRepository.revocarUltimoRefreshToken(usuario._id);
+
+    // Crear refreshToken 
+    const refreshToken = this.generarRefreshToken();
+    const hashedRefreshToken = this.hashToken(refreshToken);
+
+    // Definir fecha de expiración
+    const fechaExpiracion = generarFechaExpiracion(REFRESH_JWT_EXPIRES_IN)
+
+    //Guardar el refreshToken
+    await AuthRepository.createRefreshToken({
+      usuarioId: usuario._id,
+      tokenHash: hashedRefreshToken,
+      infoDispositivo:{
+        ip, 
+        userAgent
+      },
+      fechaExpiracion: fechaExpiracion
+    })
+
+    // Limpiar refreshTokens antiguos
+    await AuthRepository.limpiarTokensAntiguos(usuario._id)
+
+    const payload = {
+      sub: usuario._id.toString(),
+      email: usuario.email,
+      rol: usuario.rol,
+    };
+
+    // Generar accessToken
+    const accessToken = jwt.sign(payload, JWT_SECRET, { expiresIn: ACCESS_JWT_EXPIRES_IN });
+
+    const json = {
+      accessToken,
+      user: {
+        id: usuario._id,
+        nombre: usuario.nombre,
+        email: usuario.email,
+        rol: usuario.rol,
+        activo: usuario.activo,
+      },
+    }
+
+    const cookies = {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        path: "/api/auth/refreshToken",
+        maxAge: ms(REFRESH_JWT_EXPIRES_IN)
+    }
+
+    return {
+    json,
+    cookies,
+    refreshToken
+    };
+};

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -2,6 +2,7 @@
 const request = require("supertest");
 const app = require("../src/config/app"); // importar la app directamente
 const Usuario = require("../src/modules/usuarios/usuario.model");
+const RefreshToken = require("../src/modules/auth/auth.model");
 const bcrypt = require("bcrypt");
 
 describe("POST /api/auth/login", () => {
@@ -20,15 +21,28 @@ describe("POST /api/auth/login", () => {
     });
   });
 
-  it("debe autenticar y devolver token y user", async () => {
+  afterEach(async () => {
+    // Limpiar base de datos después de cada test
+    await Usuario.deleteMany({});
+    await RefreshToken.deleteMany({});
+  });
+
+  it("debe autenticar y devolver accessToken y user", async () => {
     const res = await request(app)
       .post("/api/auth/login")
       .send({ email, password: plainPassword })
       .expect(200);
 
-    expect(res.body.token).toBeDefined();
-    expect(res.body.user).toBeDefined();
-    expect(res.body.user.email).toBe(email);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.accessToken).toBeDefined();
+    expect(res.body.data.user).toBeDefined();
+    expect(res.body.data.user.email).toBe(email);
+    expect(res.body.mensaje).toBe("Inicio de sesión exitoso");
+    
+    // Verificar que se estableció la cookie refreshToken
+    const cookies = res.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+    expect(cookies.some(cookie => cookie.includes('refreshToken'))).toBe(true);
   });
 
   it("debe fallar con credenciales incorrectas", async () => {
@@ -43,5 +57,235 @@ describe("POST /api/auth/login", () => {
       .post("/api/auth/login")
       .send({ email })
       .expect(400);
+  });
+});
+
+describe("POST /api/auth/refreshToken", () => {
+  const email = "testuser@example.com";
+  const plainPassword = "Test12345!";
+  let refreshTokenCookie;
+
+  beforeEach(async () => {
+    // crear usuario con password hasheado
+    const saltRounds = parseInt(process.env.BCRYPT_SALT_ROUNDS || "10", 10);
+    const hashed = await bcrypt.hash(plainPassword, saltRounds);
+    await Usuario.create({
+      nombre: "Test User",
+      email,
+      password: hashed,
+      rol: "estudiante"
+    });
+
+    // Hacer login para obtener un refresh token
+    const loginRes = await request(app)
+      .post("/api/auth/login")
+      .send({ email, password: plainPassword });
+
+    // Extraer la cookie de refreshToken
+    refreshTokenCookie = loginRes.headers['set-cookie']
+      .find(cookie => cookie.startsWith('refreshToken='));
+  });
+
+  afterEach(async () => {
+    await Usuario.deleteMany({});
+    await RefreshToken.deleteMany({});
+  });
+
+  it("debe refrescar el token cuando se proporciona un refreshToken válido", async () => {
+    const res = await request(app)
+      .post("/api/auth/refreshToken")
+      .set('Cookie', refreshTokenCookie)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.accessToken).toBeDefined();
+    expect(res.body.data.user).toBeDefined();
+    expect(res.body.data.user.email).toBe(email);
+    expect(res.body.mensaje).toBe("Token refrescado");
+    
+    // Verificar que se estableció una nueva cookie refreshToken
+    const newCookies = res.headers['set-cookie'];
+    expect(newCookies).toBeDefined();
+    expect(newCookies.some(cookie => cookie.includes('refreshToken'))).toBe(true);
+  });
+
+  it("debe fallar cuando no se proporciona refreshToken", async () => {
+    await request(app)
+      .post("/api/auth/refreshToken")
+      .expect(400);
+  });
+
+  it("debe fallar cuando el refreshToken no es válido", async () => {
+    await request(app)
+      .post("/api/auth/refreshToken")
+      .set('Cookie', 'refreshToken=token-invalido')
+      .expect(401);
+  });
+
+  it("debe fallar cuando el usuario asociado al token no existe", async () => {
+    // Obtener token válido
+    const res = await request(app)
+      .post("/api/auth/refreshToken")
+      .set('Cookie', refreshTokenCookie);
+
+    // Eliminar el usuario para simular que ya no existe
+    await Usuario.deleteOne({ email });
+
+    // Intentar refrescar con un token de usuario eliminado
+    await request(app)
+      .post("/api/auth/refreshToken")
+      .set('Cookie', refreshTokenCookie)
+      .expect(401);
+  });
+});
+
+describe("POST /api/auth/logout", () => {
+  const email = "testuser@example.com";
+  const plainPassword = "Test12345!";
+  let accessToken;
+
+  beforeEach(async () => {
+    // crear usuario con password hasheado
+    const saltRounds = parseInt(process.env.BCRYPT_SALT_ROUNDS || "10", 10);
+    const hashed = await bcrypt.hash(plainPassword, saltRounds);
+    await Usuario.create({
+      nombre: "Test User",
+      email,
+      password: hashed,
+      rol: "estudiante"
+    });
+
+    // Hacer login para obtener access token
+    const loginRes = await request(app)
+      .post("/api/auth/login")
+      .send({ email, password: plainPassword });
+
+    accessToken = loginRes.body.data.accessToken;
+  });
+
+  afterEach(async () => {
+    await Usuario.deleteMany({});
+    await RefreshToken.deleteMany({});
+  });
+
+  it("debe cerrar sesión exitosamente con un token válido", async () => {
+    const res = await request(app)
+      .post("/api/auth/logout")
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.user).toBeDefined();
+    expect(res.body.data.user.email).toBe(email);
+    expect(res.body.mensaje).toBe("Cierre de sesión exitoso");
+
+    // Verificar que el refresh token fue revocado
+    const tokens = await RefreshToken.find({ usuarioId: res.body.data.user.id });
+    const activeTokens = tokens.filter(token => !token.fechaRevocacion);
+    expect(activeTokens.length).toBe(0);
+  });
+
+  it("debe fallar cuando no se proporciona token de autorización", async () => {
+    await request(app)
+      .post("/api/auth/logout")
+      .expect(401); // El middleware verifyToken debería rechazar la petición
+  });
+
+  it("debe fallar cuando se proporciona un token inválido", async () => {
+    await request(app)
+      .post("/api/auth/logout")
+      .set('Authorization', 'Bearer token-invalido')
+      .expect(403);
+  });
+
+  it("debe limpiar la cookie de refreshToken al hacer logout", async () => {
+    const res = await request(app)
+      .post("/api/auth/logout")
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Verificar que se envía el header para limpiar la cookie
+    const cookies = res.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+    
+    // Buscar la cookie que limpia refreshToken
+    const clearCookie = cookies.find(cookie => 
+      cookie.includes('refreshToken=;') || 
+      cookie.includes('Max-Age=0') ||
+      cookie.includes('Expires=Thu, 01 Jan 1970')
+    );
+    expect(clearCookie).toBeDefined();
+  });
+
+  it("debe permitir logout incluso si el usuario ya no existe en la base de datos", async () => {
+    // Primero obtenemos el ID del usuario
+    const user = await Usuario.findOne({ email });
+    
+    // Hacemos logout
+    const res = await request(app)
+      .post("/api/auth/logout")
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    // Eliminamos el usuario después del logout
+    await Usuario.deleteOne({ _id: user._id });
+
+    // Intentar hacer logout de nuevo con el mismo token debería fallar
+    await request(app)
+      .post("/api/auth/logout")
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(401);
+  });
+});
+
+describe("Flujo completo de autenticación", () => {
+  const email = "testuser@example.com";
+  const plainPassword = "Test12345!";
+
+  beforeEach(async () => {
+    const saltRounds = parseInt(process.env.BCRYPT_SALT_ROUNDS || "10", 10);
+    const hashed = await bcrypt.hash(plainPassword, saltRounds);
+    await Usuario.create({
+      nombre: "Test User",
+      email,
+      password: hashed,
+      rol: "estudiante"
+    });
+  });
+
+  afterEach(async () => {
+    await Usuario.deleteMany({});
+    await RefreshToken.deleteMany({});
+  });
+
+  it("debe completar el flujo login → refresh → logout exitosamente", async () => {
+    // 1. Login
+    const loginRes = await request(app)
+      .post("/api/auth/login")
+      .send({ email, password: plainPassword })
+      .expect(200);
+
+    const accessToken = loginRes.body.data.accessToken;
+    const refreshTokenCookie = loginRes.headers['set-cookie']
+      .find(cookie => cookie.startsWith('refreshToken='));
+
+    // 2. Refresh token
+    const refreshRes = await request(app)
+      .post("/api/auth/refreshToken")
+      .set('Cookie', refreshTokenCookie)
+      .expect(200);
+
+    const newAccessToken = refreshRes.body.data.accessToken;
+
+    // 3. Logout con el nuevo access token
+    await request(app)
+      .post("/api/auth/logout")
+      .set('Authorization', `Bearer ${newAccessToken}`)
+      .expect(200);
+
+    // 4. Verificar que ya no se puede usar el refresh token
+    await request(app)
+      .post("/api/auth/refreshToken")
+      .set('Cookie', refreshTokenCookie)
+      .expect(401);
   });
 });

--- a/tests/prestamo.model.test.js
+++ b/tests/prestamo.model.test.js
@@ -29,6 +29,7 @@ describe("Modelo Prestamo", () => {
     // Crear el préstamo
     const prestamo = await Prestamo.create({
       ejemplarId,
+      libroId: libro._id,
       usuarioId: usuario._id,
       fechaPrestamo: new Date("2025-08-20"),
       fechaDevolucionEstimada: new Date("2025-09-20"),


### PR DESCRIPTION

# feature: se agregaron los endpoints de refreshToken, logout y pruebas unitarias

Se modificó la lógica de negocio del módulo de autenticación implementando Auth2.0 y se agregaron los endpoints de refreshToken y logout.

---

### Autenticación (OAuth 2.0 – Access & Refresh Tokens)

El módulo de autenticación utiliza un esquema basado en **OAuth 2.0** con dos tipos de tokens:

**Access Token**

* JWT de corta duración (≈15 minutos).
* Se almacena en memoria del cliente o `localStorage`.
* Se envía como `Authorization: Bearer <token>` en los endpoints protegidos.
* Se renueva usando el endpoint `/api/auth/refreshToken`.

**Refresh Token**

* Token opaco (string aleatorio).
* Se almacena en el cliente como cookie `httpOnly`.
* En el servidor se guarda únicamente su hash.
* Se conserva solo el token activo y el inmediatamente anterior (revocado).
* Se utiliza para emitir nuevos access tokens.
* Duración típica: ~7 días.
* Al cerrar sesión, todos los refresh tokens del usuario son revocados.

---


## **POST /api/auth/login — loginUsuario**

**Descripción**:
Autentica un usuario mediante email y contraseña. Si las credenciales son correctas, genera:

* un **access token** (JWT) que se devuelve en el body (JSON) — de corta duración; y
* un **refresh token** que **no** se devuelve en el body sino que se envía en una **cookie HttpOnly** (ruta `/api/auth/refreshToken`) para uso seguro en futuras renovaciones.

---

**Body**

```json
{
  "email": "string",
  "password": "string"
}
```

---

**Response (200 OK)**

La respuesta JSON contiene el `accessToken` y la información básica del usuario:

```json
{
  "success": true,
  "data": {
    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
    "user": {
      "id": "string",
      "nombre": "string",
      "email": "string",
      "rol": "string",
      "activo": true
    }
  },
  "mensaje": "Inicio de sesión exitoso"
}
```

**Además**: el servidor establecerá una cookie `refreshToken` con flags de seguridad:

```
Set-Cookie: refreshToken=<token>; HttpOnly; Path=/api/auth/refreshToken; SameSite=Strict; Secure=(depending on env); Max-Age=<...>
```

---

**Códigos de respuesta relevantes**

* `200` — Login exitoso (cookie establecida + JSON con access token y user).
* `400` — Faltan `email` o `password`.
* `401` — Credenciales inválidas (usuario no existe o password incorrecto).
* `500` — Error del servidor.

---

**Lógica (paso a paso)**

1. Validar que `email` y `password` vienen en el body; si falta alguno → `400`.
3. Buscar el usuario por email (repositorio `UsuarioRepository.findByEmail`); si no existe → `401`.
4. Comparar contraseña (hash) con `comparePassword`; si falla → `401`.
5. Generar:

   * `accessToken` (JWT): firmado con `JWT_SECRET`, expiración corta (`ACCESS_JWT_EXPIRES_IN`, ej. `15m`).
   * `refreshToken`: token opaco (cadena aleatoria) o JWT según implementación; **se guarda en BD sólo su hash** (`tokenHash`).
6. Calcular `fechaExpiracion` del refresh token (ej. `7d`) y persistir en la colección `RefreshToken`:

   * Campos: `usuarioId`, `tokenHash` (SHA256), `infoDispositivo` (ip, userAgent), `fechaExpiracion`, timestamps.
7. Rotación/limpieza: después de crear el nuevo refresh token, se llama a `limpiarTokensAntiguos(usuarioId)` para conservar sólo los 2 más recientes (actual + anterior).
8. En la respuesta:

   * Colocar `refreshToken` en cookie `HttpOnly` con `path: "/api/auth/refreshToken"`, `sameSite: "strict"`, `maxAge` acorde a expiración.
   * Enviar JSON con `accessToken` y `user`.
9. Nota de seguridad: **NO** devolver `refreshToken` en el body JSON; mantenerlo sólo en cookie httpOnly para mitigar XSS.

---

**Consideraciones OAuth2 / seguridad**

* El `accessToken` es de corta duración y se usa para autorizar requests (cabecera `Authorization: Bearer <accessToken>`).
* El `refreshToken` se considera secreto de larga duración → se guarda hasheado en BD y se envía como cookie httpOnly.
* Rotación de refresh tokens: cuando se hace refresh, se emite un nuevo refresh token y se revoca el anterior (o se marca `reemplazadoPor`).
* TTL en BD (`fechaExpiracion` con índice TTL) elimina tokens caducados eventualmente; siempre validar `fechaExpiracion` en queries porque TTL no borra de forma inmediata.

---

---

## **POST /api/auth/refreshToken — refreshToken**

**Descripción**:
Renueva la sesión: a partir del `refreshToken` almacenado en la cookie httpOnly (`refreshToken`), valida y genera un nuevo `accessToken` y un nuevo `refreshToken` (rotación). Devuelve un nuevo `accessToken` en JSON y emite la cookie `refreshToken` actualizada.

---

**Body**

* **Ninguno**: El `refreshToken` se envía desde el cliente vía cookie `refreshToken`.

**Headers**

* No requiere `Authorization`.
* Necesita que la cookie `refreshToken` esté presente. (En Postman puedes enviar `Cookie: refreshToken=<token>` en headers o usar la pestaña Cookies.)

---

**Response (200 OK)**

```json
{
  "success": true,
  "data": {
    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
    "user": {
      "id": "string",
      "nombre": "string",
      "email": "string",
      "rol": "string",
      "activo": true
    }
  },
  "mensaje": "Token refrescado"
}
```

**Además**: el servidor enviará una nueva cookie `refreshToken` (rotada) con las mismas flags de seguridad.

---

**Códigos de respuesta relevantes**

* `200` — Refresh exitoso (cookie rotada + JSON con nuevo access token).
* `400` — Cookie `refreshToken` no enviada.
* `401` — Refresh token inválido, revocado o usuario no encontrado.
* `500` — Error del servidor.

---

**Lógica (paso a paso)**

1. Obtener `refreshToken` desde `req.cookies.refreshToken`. Si no existe → `400`.
2. Calcular `tokenHash = hash(refreshToken)` con SHA256 (mismo algoritmo usado al guardar).
3. Buscar registro en BD por `tokenHash` (`AuthRepository.findbyHashToken`):

   * Si no existe → `401`.
   * Si `fechaRevocacion` existe o `fechaExpiracion <= now` → `401`.
4. Cargar el `usuario` asociado (`UsuarioRepository.findById`). Si no existe → `401`.
5. (Opcional/seguridad) Detectar reuse: si se identifica uso de un token ya reemplazado → tomar medidas (revocar todos, alertar).
6. Generar:

   * `nuevoAccessToken` (JWT) con `ACCESS_JWT_EXPIRES_IN`.
   * `nuevoRefreshToken` opaco (cadena aleatoria).
7. Guardar hash del `nuevoRefreshToken` en BD como nuevo documento (o actualizar el documento existente), setear `reemplazadoPor` en el anterior y `fechaRevocacion` si aplica.
8. Llamar `limpiarTokensAntiguos(usuarioId)` para mantener sólo 2 tokens.
10. Enviar la cookie `refreshToken` con `Set-Cookie` (httpOnly) y responder JSON con `accessToken` y `user`.
11. Si algo falla -> devolver `401` (refresh inválido) o `500`.

---

**Notas sobre seguridad / OAuth2**

* **Rotación**: cada refresh genera nuevo refresh token y el anterior queda invalidado.
* Evitar enviar refresh token en body o en localStorage. Cookie httpOnly es la opción segura.
* Validar `userAgent` / IP opcionalmente para aumentar detección de abuso.

---

---

## **POST /api/auth/logout — logoutUsuario**

**Descripción**:
Cierra la sesión del usuario actual. Requiere autorización (middleware `verifyToken` que valida el access token). En el backend se revoca el refresh token correspondiente y se limpia la cookie `refreshToken`. El access token en posesión del cliente debe eliminarse en el cliente (frontend) y expirará por su corta vida.

---

**Headers**

```http
Authorization: Bearer <accessToken>
Cookie: refreshToken=<refreshToken>   // opcional, pero backend revoca por usuario
```

---

**Body**

* **Ninguno**. 
---

**Response**

* **200 OK (o 204 No Content)** — según implementación. Ejemplo JSON:

```json
{
    "success": true,
    "data": {
        "user": {
      "id": "string",
      "nombre": "string",
      "email": "string",
      "rol": "string",
      "activo": true
    }
    },
    "mensaje": "Cierre de sesión exitoso"
}
```

El servidor también **borra la cookie**:

```
Set-Cookie: refreshToken=; Path=/api/auth/refreshToken; Max-Age=0
```

---

**Códigos de respuesta relevantes**

* `200` o `204` — Logout exitoso.
* `401` — token de acceso inválido/no provisto (middleware `verifyToken`).
* `500` — Error del servidor.

---

**Lógica (paso a paso)**

1. El middleware `verifyToken` valida el `accessToken` (firma, expiración). Si inválido → `401`.
2. Obtener `usuarioId` desde el claim `sub` del JWT (`req.user.sub`).
3. En el servicio:

   * Revocar token(s) de refresh asociado(s): típicamente `revocarUltimoRefreshToken(usuarioId)` o `revocarTodosLosTokens(usuarioId)` según el comportamiento deseado (logout local vs global).
   * Esto consiste en setear `fechaRevocacion = now` para el registro correspondiente o eliminar el registro.
4. Borrar la cookie en la respuesta (`res.clearCookie("refreshToken", { path: "/api/auth/refreshToken" })`).
5. Responder con status final: `204 No Content` o `200` con JSON indicando éxito.
6. En el cliente: borrar el `accessToken` de memoria / almacenamiento (ej. `localStorage.removeItem("accessToken")` o limpiar estado).

---

**Consideraciones adicionales**

* El `accessToken` *no* se revoca en el backend (salvo que implementes blacklist). Se acepta que expirará en su corto tiempo de vida.
* Si necesitas invalidar access tokens inmediatamente, debes introducir un sistema de blacklist en Redis o usar `tokenVersion` en el usuario y verificarlo en cada request.


---